### PR TITLE
Feat: Adiciona comandos CLI com '//' e configuração via arquivo .env

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,21 @@
+# Configurações para CPU LLM Project
+# Este é um arquivo de exemplo. Copie para .env e ajuste os valores conforme necessário.
+
+# Configurações do Modelo e Engine
+NUM_THREADS=0           # Número de threads para o Llama Engine. 0 = automático (baseado nos núcleos da CPU, com limite).
+MODEL_N_CTX=2048        # Tamanho máximo do contexto do modelo.
+DEFAULT_MODEL_PATH=""   # Caminho padrão para o arquivo .gguf do modelo (opcional, se não fornecido via CLI).
+
+# Parâmetros de Amostragem (usados quando a geração de texto avançada for restaurada)
+MODEL_TEMPERATURE=0.8
+MODEL_TOP_K=40
+MODEL_TOP_P=0.9
+MODEL_REPEAT_PENALTY=1.1
+# MAX_TOKENS_TO_GENERATE=128 # Pode ser definido aqui também, ou via API/parâmetro de função
+
+# System Prompt (usado quando a geração de texto for restaurada e integrada)
+SYSTEM_PROMPT="Você é um assistente de IA prestativo e conciso."
+
+# Configurações do Servidor API (se o modo servidor for ativado)
+API_HOST="localhost"
+API_PORT=8080

--- a/README.md
+++ b/README.md
@@ -37,17 +37,39 @@ Este projeto visa ser uma alternativa ao Ollama, otimizado para inferência efic
     ```
     O executável principal será `build/bin/cpu_llm_project`.
 
+## Configuração (Arquivo `.env`)
+
+Opcionalmente, você pode criar um arquivo chamado `.env` na raiz do projeto para definir configurações padrão. Copie o arquivo `.env-example` para `.env` e ajuste os valores conforme necessário.
+
+Variáveis suportadas no `.env`:
+*   `NUM_THREADS=0`           # Número de threads (0 = automático)
+*   `MODEL_N_CTX=2048`        # Tamanho do contexto
+*   `DEFAULT_MODEL_PATH=""`   # Caminho padrão do modelo (atualmente não usado para sobrescrever o argumento obrigatório)
+*   `MODEL_TEMPERATURE=0.8`   # Temperatura de amostragem
+*   `MODEL_TOP_K=40`          # Top-K
+*   `MODEL_TOP_P=0.9`         # Top-P
+*   `MODEL_REPEAT_PENALTY=1.1`# Penalidade de repetição
+*   `SYSTEM_PROMPT="Você é um assistente de IA prestativo e conciso."` # Prompt de sistema padrão
+*   `API_HOST="localhost"`    # Host padrão para o servidor API
+*   `API_PORT=8080`         # Porta padrão para o servidor API
+
+**Prioridade das Configurações:**
+1.  Argumentos de linha de comando (têm a maior prioridade).
+2.  Variáveis definidas no arquivo `.env`.
+3.  Valores padrão definidos no código.
+
 ## Como Executar
 
 O `cpu_llm_project` pode ser executado em dois modos principais: como um servidor API HTTP ou em modo interativo de linha de comando (CLI). Todos os argumentos de linha de comando após o caminho do modelo são opcionais e podem ser fornecidos como flags nomeadas.
 
-**Argumentos Comuns (Opcionais):**
+**Argumentos de Linha de Comando:**
 
-*   `--host <hostname>`: Define o host para o servidor API (padrão: `localhost`). Usado apenas no modo servidor.
-*   `--port <numero_porta>`: Define a porta para o servidor API (padrão: `8080`). Usado apenas no modo servidor.
-*   `--n_ctx <numero>`: Define o tamanho do contexto para o modelo (padrão: `2048`).
-*   `--threads <numero>`: Define o número de threads que o motor LLM deve usar (padrão: automático, baseado nos núcleos da CPU com um limite superior). Um valor `<= 0` usa o padrão.
-*   `--interactive`: Força o programa a iniciar em modo interativo CLI, mesmo que argumentos de host/porta sejam fornecidos.
+*   `<caminho_para_modelo.gguf>`: **Obrigatório.** O primeiro argumento posicional deve ser o caminho para o arquivo do modelo GGUF.
+*   `--host <hostname>`: Define o host para o servidor API. Sobrescreve `API_HOST` do `.env`.
+*   `--port <numero_porta>`: Define a porta para o servidor API. Sobrescreve `API_PORT` do `.env`.
+*   `--n_ctx <numero>`: Define o tamanho do contexto. Sobrescreve `MODEL_N_CTX` do `.env`.
+*   `--threads <numero>`: Define o número de threads. Sobrescreve `NUM_THREADS` do `.env`.
+*   `--interactive`: Força o modo interativo CLI. Tem prioridade sobre as flags de servidor.
 
 ### Modo Servidor API
 
@@ -101,12 +123,13 @@ Info: Suporte a AVX detectado em tempo de execução.
 [...]
 Modelo /caminho/para/seu/modelo.gguf carregado com sucesso no LlmEngine.
 
-Modo Interativo. Digite 'sair', 'exit' ou 'quit' para terminar.
+Modo Interativo. Digite '//sair', '//exit' ou '//quit' para terminar.
 
 Prompt:
 ```
 *   Digite seu prompt e pressione Enter.
-*   Para sair, digite `sair`, `exit`, ou `quit` e pressione Enter, ou pressione `Ctrl+D` (EOF).
+*   Para executar comandos, use o prefixo `//`. Exemplo: `//sair`.
+*   Comandos de saída disponíveis: `//sair`, `//exit`, `//quit`. Você também pode usar `Ctrl+D` (EOF).
 
 **Nota sobre a Geração de Texto:**
 Atualmente, a funcionalidade de geração de texto no `LlmEngine` está simplificada para garantir a compilação do projeto (devido a desafios com a API `llama.cpp`). No modo interativo, a "resposta" do modelo será uma mensagem informativa estática: `[INFO: Text generation loop disabled for compilation. Processed prompt.]`. A restauração da capacidade completa de geração de texto e amostragem avançada é um trabalho futuro.

--- a/include/cpu_llm_project/llm_engine.hpp
+++ b/include/cpu_llm_project/llm_engine.hpp
@@ -28,7 +28,9 @@ public:
     void unload_model();
 
     // Gera texto a partir de um prompt.
-    std::string predict(const std::string& prompt,
+    // Os parâmetros de amostragem são incluídos para uso futuro quando a amostragem avançada for restaurada.
+    std::string predict(const std::string& user_prompt,
+                        const std::string& system_prompt = "", // System prompt opcional
                         int max_tokens = 128,
                         float temp = 0.8f,
                         int top_k = 40,

--- a/src/api_server.cpp
+++ b/src/api_server.cpp
@@ -131,9 +131,21 @@ void ApiServer::post_generate(const httplib::Request& req, httplib::Response& re
     float top_p = request_json.value("top_p", 0.9f);
     float repeat_penalty = request_json.value("repeat_penalty", 1.1f);
     // bool stream = request_json.value("stream", false); // Streaming não implementado ainda
+    std::string system_prompt_req = request_json.value("system_prompt", ""); // Novo campo opcional
 
     std::cout << "ApiServer::post_generate: Received prompt: \"" << prompt << "\"" << std::endl;
-    std::string generated_text = engine_.predict(prompt, max_tokens, temp, top_k, top_p, repeat_penalty);
+    if (!system_prompt_req.empty()) {
+        std::cout << "ApiServer::post_generate: Using system prompt: \"" << system_prompt_req << "\"" << std::endl;
+    }
+    // Passar o system_prompt para engine_.predict()
+    // Se system_prompt_req estiver vazio, o LlmEngine usará seu próprio padrão (se houver) ou nada.
+    std::string generated_text = engine_.predict(prompt,
+                                                 system_prompt_req,
+                                                 max_tokens,
+                                                 temp,
+                                                 top_k,
+                                                 top_p,
+                                                 repeat_penalty);
     std::cout << "ApiServer::post_generate: Generated response: \"" << generated_text << "\"" << std::endl;
 
     json response_data;

--- a/tests/test_llm_engine.cpp
+++ b/tests/test_llm_engine.cpp
@@ -91,7 +91,8 @@ TEST_CASE("LlmEngine Prediction Logic (without full model load)", "[llm_engine]"
     cpu_llm_project::LlmEngine engine;
 
     SECTION("Predict without a loaded model") {
-        std::string result = engine.predict("Hello", 10);
+        // Passar system_prompt vazio e usar valores padrão para outros params de amostragem
+        std::string result = engine.predict("Hello", "", 10);
         INFO("Result: " << result); // Para debug, se o teste falhar
         REQUIRE(result.rfind("[Error: Model not loaded]", 0) == 0); // Verifica se começa com a msg de erro
     }


### PR DESCRIPTION
- Modifica o modo interativo para aceitar comandos prefixados com `//` (ex: `//sair`). Comandos de saída legados são mantidos com aviso.
- Cria o arquivo `.env-example` com variáveis de configuração para threads, parâmetros de modelo/amostragem, system prompt e servidor API.
- Implementa a leitura de um arquivo `.env` no `main.cpp` para carregar configurações padrão. A prioridade das configurações é: Argumentos CLI > Arquivo .env > Padrões no código.
- Atualiza `LlmEngine::predict` para aceitar `system_prompt` e parâmetros de amostragem. O `system_prompt` é agora prefixado ao seu prompt. (A lógica de amostragem avançada ainda está pendente).
- Atualiza `main.cpp` e `api_server.cpp` para passar os novos parâmetros para `engine.predict()`.